### PR TITLE
task07

### DIFF
--- a/tasks/ihor_kliushnikov/task07/1-deque.cs
+++ b/tasks/ihor_kliushnikov/task07/1-deque.cs
@@ -1,0 +1,97 @@
+﻿using System;
+
+namespace ConsoleApplication1.DataStructures
+{
+    public class Deque<T>
+    {
+        private StackItem<T> _headStack;
+        private StackItem<T> _tailStack;
+
+        public void PushHead(T value)
+        {
+            if (_headStack == null)
+                _headStack = new StackItem<T>(value);
+            else
+            {
+                var newStack = new StackItem<T>(value, _headStack);
+                _headStack = newStack;
+            }
+        }
+
+        public T PopHead()
+        {
+            if (_headStack == null && _tailStack == null)
+                throw new InvalidOperationException("Queue is empty");
+
+            if (_headStack == null)
+            {
+                _headStack = _tailStack.GetInverted();
+                _tailStack = null;
+            }
+
+            var popValue = _headStack.Value;
+            var nextStackItem = _headStack.Next;
+            _headStack = nextStackItem;
+
+            return popValue;
+        }
+
+        public void PushTail(T value)
+        {
+            if (_tailStack == null)
+                _tailStack = new StackItem<T>(value);
+            else
+            {
+                var newStack = new StackItem<T>(value, _tailStack);
+                _tailStack = newStack;
+            }
+        }
+
+        public T PopTail()
+        {
+            if (_tailStack == null && _headStack == null)
+                throw new InvalidOperationException("Queue is empty");
+
+            if (_tailStack == null)
+            {
+                _tailStack = _headStack.GetInverted();
+                _headStack = null;
+            }
+
+            var popValue = _tailStack.Value;
+            var nextStackItem = _tailStack.Next;
+            _tailStack = nextStackItem;
+
+            return popValue;
+        }
+		
+		class StackItem<T>
+		{
+			public StackItem(T value, StackItem<T> next = null)
+			{
+				Value = value;
+				Next = next;
+			}
+
+			public T Value { get; private set; }
+	
+			public StackItem<T> Next { get; private set; }
+	
+			public StackItem<T> GetInverted()
+			{
+				var head = this;
+				var invertedStack = new StackItem<T>(Value);
+
+				while (head.Next != null)
+				{
+					var nextStackItem = new StackItem<T>(head.Next.Value, invertedStack);
+					invertedStack = nextStackItem;
+	
+					head = head.Next;
+				}
+
+				return invertedStack;
+			}
+		}
+    }
+}

--- a/tasks/ihor_kliushnikov/task07/1-queue.cs
+++ b/tasks/ihor_kliushnikov/task07/1-queue.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+namespace ConsoleApplication1.DataStructures
+{
+    public class Queue<T>
+    {
+        private StackItem<T> _writeStack;
+        private StackItem<T> _readStack;
+
+        public void Push(T value)
+        {
+            if (_writeStack == null)
+                _writeStack = new StackItem<T>(value);
+            else
+            {
+                var newStack = new StackItem<T>(value, _writeStack);
+                _writeStack = newStack;
+            }
+        }
+
+        public T Pop()
+        {
+            if (_readStack == null && _writeStack == null)
+                throw new InvalidOperationException("Queue is empty");
+
+            if (_readStack == null)
+            {
+                _readStack = _writeStack.GetInverted();
+                _writeStack = null;
+            }
+
+            var popValue = _readStack.Value;
+            var nextStackItem = _readStack.Next;
+            _readStack = nextStackItem;
+
+            return popValue;
+        }
+		
+		class StackItem<T>
+		{
+			public StackItem(T value, StackItem<T> next = null)
+			{
+				Value = value;
+				Next = next;
+			}
+
+			public T Value { get; private set; }
+	
+			public StackItem<T> Next { get; private set; }
+	
+			public StackItem<T> GetInverted()
+			{
+				var head = this;
+				var invertedStack = new StackItem<T>(Value);
+
+				while (head.Next != null)
+				{
+					var nextStackItem = new StackItem<T>(head.Next.Value, invertedStack);
+					invertedStack = nextStackItem;
+	
+					head = head.Next;
+				}
+
+				return invertedStack;
+			}
+		}
+    }
+}

--- a/tasks/ihor_kliushnikov/task07/2-sets.cs
+++ b/tasks/ihor_kliushnikov/task07/2-sets.cs
@@ -27,6 +27,9 @@ namespace ConsoleApplication1.DataStructures
 
                 yield return a;
             }
+
+            for (var i = j; i < other.Length; i++)
+                yield return other[i];
         }
 
         public IEnumerable<int> Intersection(Set otherSet)
@@ -36,7 +39,7 @@ namespace ConsoleApplication1.DataStructures
 
             foreach (var a in Values)
             {
-                while (j < other.Length && a > other[j])
+                while (j < other.Length - 1 && a > other[j])
                     j++;
 
                 if (a == other[j])
@@ -51,7 +54,7 @@ namespace ConsoleApplication1.DataStructures
 
             foreach (var a in Values)
             {
-                while (j < other.Length && a > other[j])
+                while (j < other.Length - 1 && a > other[j])
                     j++;
 
                 if (a != other[j])

--- a/tasks/ihor_kliushnikov/task07/2-sets.cs
+++ b/tasks/ihor_kliushnikov/task07/2-sets.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+
+namespace ConsoleApplication1.DataStructures
+{
+    public class Set
+    {
+        public Set(int[] array)
+        {
+            Values = array;
+        }
+
+        public readonly int[] Values;
+
+        public IEnumerable<int> Union(Set otherSet)
+        {
+            var other = otherSet.Values;
+            var j = 0;
+
+            foreach (var a in Values)
+            {
+                while (j < other.Length && a >= other[j])
+                {
+                    if (a != other[j])
+                        yield return other[j];
+                    j++;
+                }
+
+                yield return a;
+            }
+        }
+
+        public IEnumerable<int> Intersection(Set otherSet)
+        {
+            var other = otherSet.Values;
+            var j = 0;
+
+            foreach (var a in Values)
+            {
+                while (j < other.Length && a > other[j])
+                    j++;
+
+                if (a == other[j])
+                    yield return a;
+            }
+        }
+
+        public IEnumerable<int> Complement(Set otherSet)
+        {
+            var other = otherSet.Values;
+            var j = 0;
+
+            foreach (var a in Values)
+            {
+                while (j < other.Length && a > other[j])
+                    j++;
+
+                if (a != other[j])
+                    yield return a;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Для Deque можна додатово додавати балансування згідно шаблонів по використанню:
- для черг, де в більшості використовуються операції Pop лише для голови, при спробі отримати значення з пустого хвоста - переносити лише 1 елемент у відповідний стек (аналогічно для протилежної ситуації з інтенсивним використанням хвоста).
- для рівномірного використання операцій Рор для обох сторін - при переносі значень між стеками ділити їх навпіл, замість повного перенесення. Наприклад, при пустому хвості і 10 елементах у голові - перенести лише 5 елементів у хвіст, а решту залишити у голові.
